### PR TITLE
Parenthesis handling update.

### DIFF
--- a/scripts/upgradespells.lua
+++ b/scripts/upgradespells.lua
@@ -46,10 +46,6 @@ local function trim_spell_name(string_spell_name)
 		string_spell_name = string_spell_name:gsub('Quickened', '')
 	end
 
-	-- remove anything after open parentheses
-	local number_name_end = string.find(string_spell_name, '%(')
-	string_spell_name = string_spell_name:sub(1, number_name_end)
-
 	-- remove certain sets of characters
 	string_spell_name = string_spell_name:gsub('%u%u%u%u', '')
 	string_spell_name = string_spell_name:gsub('%u%u%u', '')
@@ -57,7 +53,8 @@ local function trim_spell_name(string_spell_name)
 	string_spell_name = string_spell_name:gsub('%u%u', '')
 	string_spell_name = string_spell_name:gsub('.+:', '')
 	string_spell_name = string_spell_name:gsub(',.+', '')
-	string_spell_name = string_spell_name:gsub('%[%a%]', '')
+	string_spell_name = string_spell_name:gsub('%[.-%]', '')
+	string_spell_name = string_spell_name:gsub('%(.-%)', '')
 	string_spell_name = string_spell_name:gsub('%A+', '')
 
 	-- remove uppercase D or M at end of name


### PR DESCRIPTION
Altered parenthesis removal to accommodate multiples in description like "(1/day) slow (DC 17)". This is happening in my purchased module for Reign of Winter. Updated the brackets while I was at it. Small note, the "-" multiples modifier is "lazy" meaning that it consumes as few characters as possible while matching the pattern. If it were "+", it'd be greedy and remove the entire spell name (from first "(" to last ")").  This way it removes from open to close twice. I had to look that up, so thought I'd share the learning, in case that were new...